### PR TITLE
Drop charset from MySQL's RESERVED_KEYWORDS.

### DIFF
--- a/orator/connectors/mysql_connector.py
+++ b/orator/connectors/mysql_connector.py
@@ -22,7 +22,7 @@ class MySqlConnector(Connector):
 
     RESERVED_KEYWORDS = [
         'log_queries', 'driver', 'prefix',
-        'engine', 'charset', 'collation',
+        'engine', 'collation',
         'name'
     ]
 


### PR DESCRIPTION
Hi, thank you for creating nice library.

I found charset problem.

If I set charset=utf8 in config, orator connection ignore charset and connect to MySQL(using PyMySQL) as laten1.
This commit fixs to not ignore charset.

For example,
```python
from orator import DatabaseManager, Model

config = {
    'mysql': {
        'driver': 'mysql',
        'host': 'localhost',
        'database': 'dbname',
        'user': 'username',
        'charset': 'utf8',
        'password': 'password',
    }                        
}
                                 
db = DatabaseManager(config)     
Model.set_connection_resolver(db)

print(db.connection().get_config('charset'))    # utf8
print(db.connection().get_connection().charset) # laten1
```

`print(db.connection().get_config('charset'))` is `utf8`.
but `MySQL connetion` is `laten1`.

Ignore charset is a big problem at multi byte enviorment.
If table contains multi bye string(utf8 string), orator returns broken result.

Please check and include this.