### PR TITLE
Blueprint.char() should add column not command

### DIFF
--- a/orator/schema/blueprint.py
+++ b/orator/schema/blueprint.py
@@ -310,7 +310,7 @@ class Blueprint(object):
 
         :rtype: Fluent
         """
-        return self._add_command('char', column, length=length)
+        return self._add_column('char', column, length=length)
 
     def string(self, column, length=255):
         """


### PR DESCRIPTION
char calls self._add_comand() which fails since it only takes a single positional argument
and two positional arguments are given.

Compare this function to Blueprint.string() which calls self._add_column() and it's clear 
that the intent of this function is to do the same.