### PR TITLE
Update README to refer to `user`, not `username`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -52,7 +52,7 @@ and passing it to a ``DatabaseManager`` instance.
             'driver': 'mysql',
             'host': 'localhost',
             'database': 'database',
-            'username': 'root',
+            'user': 'root',
             'password': '',
             'prefix': ''
         }
@@ -785,7 +785,7 @@ Here is an example of how read / write connections should be configured:
             },
             'driver': 'mysql',
             'database': 'database',
-            'username': 'root',
+            'user': 'root',
             'password': '',
             'prefix': ''
         }


### PR DESCRIPTION
The docs seem to conflict themselves on this [1], but I believe the correct
key here is actually `user`, not `username.

[1] See https://orator-orm.com/docs/0.8/basic_usage.html for examples of
both `user` and `username` as a key.