### PR TITLE
Add standard name resolution to the purge method

### DIFF
--- a/orator/database_manager.py
+++ b/orator/database_manager.py
@@ -75,6 +75,9 @@ class BaseDatabaseManager(ConnectionResolverInterface):
 
         :rtype: None
         """
+        if name is None:
+            name = self.get_default_connection()
+
         self.disconnect(name)
 
         if name in self._connections:


### PR DESCRIPTION
All methods in database manager treat `name` == `None` as
`name` == `self.get_default_connection()`  Purge almost works this way, except
for the `name` it cleans up from the `_connections` cache.

Fixes this behavior so that `None` cleans up cache entries properly