### PR TITLE
except TypeError when using Collection.get

### DIFF
--- a/orator/support/collection.py
+++ b/orator/support/collection.py
@@ -396,7 +396,7 @@ class Collection(object):
 
         try:
             return self.items[key]
-        except IndexError:
+        except (IndexError, TypeError):
             return value(default)
 
     def implode(self, value, glue=''):


### PR DESCRIPTION
> users = User.all()
> users.get('name', 'default')
> Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
    users.get('name', 'default')
  File "/home/agnewee/mydir/python/orator/env/local/lib/python2.7/site-packages/orator/support/collection.py", line 398, in get
    return self.items[key]
TypeError: list indices must be integers, not str