### PR TITLE
fix Connection.get error

### DIFF
--- a/orator/support/collection.py
+++ b/orator/support/collection.py
@@ -393,10 +393,21 @@ class Collection(object):
                 return self[key]
 
             return value(default)
+            
+        if isinstance(self.items, list):
+            results = []
+            for item in self.items:
+                try:
+                    if hasattr(item, key):
+                        results.append(eval('item.{}'.format(key)))
+                except TypeError:
+                    break
+            if results:
+                return results
 
         try:
             return self.items[key]
-        except IndexError:
+        except (IndexError, TypeError):
             return value(default)
 
     def implode(self, value, glue=''):

--- a/orator/support/collection.py
+++ b/orator/support/collection.py
@@ -399,7 +399,7 @@ class Collection(object):
             for item in self.items:
                 try:
                     if hasattr(item, key):
-                        results.append(eval('item.{}'.format(key)))
+                        results.append(getattr(item, key))
                 except TypeError:
                     break
             if results:


### PR DESCRIPTION
it would raise TypeError when i use users which get from User.all()
i think it should return a list including all values of key
just like:
> users = User.all()
> users.get('name', 'default')
> Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
    users.get('name', 'default')
  File "/home/agnewee/mydir/python/orator/env/local/lib/python2.7/site-packages/orator/support/collection.py", line 398, in get
    return self.items[key]
TypeError: list indices must be integers, not str