### PR TITLE
Identify 'connection already closed' as a lost connection exception

### DIFF
--- a/orator/connections/connection.py
+++ b/orator/connections/connection.py
@@ -320,6 +320,7 @@ class Connection(ConnectionInterface):
         message = str(e)
 
         for s in ['server has gone away',
+                  'connection already closed',
                   'no connection to the server',
                   'Lost Connection',
                   'is dead or not enabled',


### PR DESCRIPTION
Issue #135 

Confirmed the fix with manual testing.

Checking exception strings doesn't seem like the best possible solution here, but the only other option that I can think of at the moment would be catching and translating all kinds of exceptions in the connector classes, and that doesn't seem great either.