### PR TITLE
Show the migration's file name when creating one

### DIFF
--- a/orator/commands/migrations/make_command.py
+++ b/orator/commands/migrations/make_command.py
@@ -35,9 +35,11 @@ class MigrateMakeCommand(BaseCommand):
         if path is None:
             path = self._get_migration_path()
 
-        self._write_migration(creator, name, table, create, path)
+        migration_name = self._write_migration(
+            creator, name, table, create, path)
 
-        self.info('<info>Migration created successfully</info>')
+        self.info(
+            '<info>Migration %s created successfully</info>' % migration_name)
 
     def _write_migration(self, creator, name, table, create, path):
         """


### PR DESCRIPTION
Pretty self-explanatory title :)

I searched the tests, and it appears that there are no tests for outputting to stdout. Thus, I didn't write it here as well. Please let me know if that's not the case.

Closes #138