### PR TITLE
allow --force option in migrations

### DIFF
--- a/orator/commands/migrations/migrate_command.py
+++ b/orator/commands/migrations/migrate_command.py
@@ -15,9 +15,12 @@ class MigrateCommand(BaseCommand):
         {--seed-path= : The path of seeds files to be executed.
                         Defaults to <comment>./seeders</comment>.}
         {--P|pretend : Dump the SQL queries that would be run.}
+        {--f|force : Run the command without user prompts.}
     """
 
     def handle(self):
+        self.input.set_interactive(not self.option('force'))
+
         confirm = self.confirm(
             '<question>Are you sure you want to proceed with the migration?</question> ',
             False

--- a/orator/commands/migrations/reset_command.py
+++ b/orator/commands/migrations/reset_command.py
@@ -12,12 +12,15 @@ class ResetCommand(BaseCommand):
         {--d|database= : The database connection to use.}
         {--p|path= : The path of migrations files to be executed.}
         {--P|pretend : Dump the SQL queries that would be run.}
+        {--f|force : Run the command without user prompts.}
     """
 
     def handle(self):
         """
         Executes the command.
         """
+        self.input.set_interactive(not self.option('force'))
+
         confirm = self.confirm(
             '<question>Are you sure you want to reset all of the migrations?</question> ',
             False

--- a/orator/commands/migrations/rollback_command.py
+++ b/orator/commands/migrations/rollback_command.py
@@ -12,12 +12,15 @@ class RollbackCommand(BaseCommand):
         {--d|database= : The database connection to use.}
         {--p|path= : The path of migrations files to be executed.}
         {--P|pretend : Dump the SQL queries that would be run.}
+        {--f|force : Run the command without user prompts.}
     """
 
     def handle(self):
         """
         Executes the command.
         """
+        self.input.set_interactive(not self.option('force'))
+
         confirm = self.confirm(
             '<question>Are you sure you want to rollback the last migration?</question> ',
             True

--- a/tests/commands/__init__.py
+++ b/tests/commands/__init__.py
@@ -10,7 +10,7 @@ class OratorCommandTestCase(OratorTestCase):
     def tearDown(self):
         flexmock_teardown()
 
-    def run_command(self, command, options=None, input_stream=None):
+    def run_command(self, command, options=None):
         """
         Run the command.
 
@@ -25,13 +25,7 @@ class OratorCommandTestCase(OratorTestCase):
         application = Application()
         application.add(command)
 
-        if input_stream:
-            dialog = command.get_helper('question')
-            dialog.__class__.input_stream = input_stream
-
         command_tester = CommandTester(command)
         command_tester.execute(options)
 
         return command_tester
-
-

--- a/tests/commands/migrations/test_reset_command.py
+++ b/tests/commands/migrations/test_reset_command.py
@@ -1,12 +1,10 @@
 # -*- coding: utf-8 -*-
 
 import os
-from io import BytesIO
 from flexmock import flexmock
 from orator.migrations import Migrator
 from orator.commands.migrations import ResetCommand
 from orator import DatabaseManager
-from orator.connections import Connection
 from .. import OratorCommandTestCase
 
 
@@ -25,8 +23,9 @@ class ResetCommandTestCase(OratorCommandTestCase):
 
         command = flexmock(ResetCommand())
         command.should_receive('_get_config').and_return({})
+        command.should_receive('confirm').and_return(True)
 
-        self.run_command(command, input_stream=self.get_input_stream('y\n'))
+        self.run_command(command)
 
     def test_migration_can_be_pretended(self):
         resolver = flexmock(DatabaseManager)
@@ -41,8 +40,9 @@ class ResetCommandTestCase(OratorCommandTestCase):
 
         command = flexmock(ResetCommand())
         command.should_receive('_get_config').and_return({})
+        command.should_receive('confirm').and_return(True)
 
-        self.run_command(command, [('--pretend', True)], input_stream=self.get_input_stream('y\n'))
+        self.run_command(command, [('--pretend', True)])
 
     def test_migration_database_can_be_set(self):
         resolver = flexmock(DatabaseManager)
@@ -57,12 +57,22 @@ class ResetCommandTestCase(OratorCommandTestCase):
 
         command = flexmock(ResetCommand())
         command.should_receive('_get_config').and_return({})
+        command.should_receive('confirm').and_return(True)
 
-        self.run_command(command, [('--database', 'foo')], input_stream=self.get_input_stream('y\n'))
+        self.run_command(command, [('--database', 'foo')])
 
-    def get_input_stream(self, input_):
-        stream = BytesIO()
-        stream.write(input_.encode())
-        stream.seek(0)
+    def test_migration_can_be_forced(self):
+        resolver = flexmock(DatabaseManager)
+        resolver.should_receive('connection').and_return(None)
 
-        return stream
+        migrator_mock = flexmock(Migrator)
+        migrator_mock.should_receive('set_connection').once().with_args(None)
+        migrator_mock.should_receive('reset').once()\
+            .with_args(os.path.join(os.getcwd(), 'migrations'), False)\
+            .and_return(2)
+        migrator_mock.should_receive('get_notes').and_return([])
+
+        command = flexmock(ResetCommand())
+        command.should_receive('_get_config').and_return({})
+
+        self.run_command(command, [('--force', True)])


### PR DESCRIPTION
Laravel's migrations have a --force option to suppress user confirmations that is super convenient for deployments and for firing migrations from within code. This gives Orator the same capability.

I also removed the input stream option from the command tests because, with the force option tests, explicitly checking for confirm seemed clearer and allowed the tests to fail instead of hanging indefinitely if input wasn't provided.