### PR TITLE
allow count distinct to get columns from select

### DIFF
--- a/orator/query/builder.py
+++ b/orator/query/builder.py
@@ -1251,6 +1251,9 @@ class QueryBuilder(object):
         :return: The count
         :rtype: int
         """
+        if not columns and self.distinct_:
+            columns = self.columns
+        
         if not columns:
             columns = ['*']
 

--- a/tests/query/test_query_builder.py
+++ b/tests/query/test_query_builder.py
@@ -1049,6 +1049,32 @@ class QueryBuilderTestCase(OratorTestCase):
         builder.get_processor().process_select.assert_called_once_with(builder, results)
         self.assertEqual(1, result)
 
+    def test_distinct_count_with_column(self):
+        builder = self.get_builder()
+        query = 'SELECT COUNT(DISTINCT "id") AS aggregate FROM "users"'
+        results = [{'aggregate': 1}]
+        builder.get_connection().select.return_value = results
+        builder.get_processor().process_select = mock.MagicMock(side_effect=lambda builder_, results_: results)
+        result = builder.from_('users').distinct().count('id')
+        builder.get_connection().select.assert_called_once_with(
+            query, [], True
+        )
+        builder.get_processor().process_select.assert_called_once_with(builder, results)
+        self.assertEqual(1, result)
+
+    def test_distinct_count_with_select(self):
+        builder = self.get_builder()
+        query = 'SELECT COUNT(DISTINCT "id") AS aggregate FROM "users"'
+        results = [{'aggregate': 1}]
+        builder.get_connection().select.return_value = results
+        builder.get_processor().process_select = mock.MagicMock(side_effect=lambda builder_, results_: results)
+        result = builder.from_('users').distinct().select('id').count()
+        builder.get_connection().select.assert_called_once_with(
+            query, [], True
+        )
+        builder.get_processor().process_select.assert_called_once_with(builder, results)
+        self.assertEqual(1, result)
+
     def test_aggregate_reset_followed_by_get(self):
         builder = self.get_builder()
         query = 'SELECT COUNT(*) AS aggregate FROM "users"'


### PR DESCRIPTION
fixes issue #134 

It always would have worked via builder.distinct().count('id'), but I made a change to have builder.distinct().select('id').count() work the same way since that seems to be the expected behavior. I do think this makes sense because it allows you to not worry about what has happened to the builder previously. 