### PR TITLE
Migrate:refresh should only run seeders with --seed option

### DIFF
--- a/orator/commands/migrations/refresh_command.py
+++ b/orator/commands/migrations/refresh_command.py
@@ -12,7 +12,7 @@ class RefreshCommand(BaseCommand):
         {--p|path= : The path of migrations files to be executed.}
         {--s|seed : Indicates if the seed task should be re-run.}
         {--seed-path= : The path of seeds files to be executed.
-                        Defaults to <comment>./seeders</comment>.}
+                        Defaults to <comment>./seeds</comment>.}
         {--seeder=database_seeder : The name of the root seeder.}
     """
 

--- a/orator/commands/migrations/refresh_command.py
+++ b/orator/commands/migrations/refresh_command.py
@@ -50,7 +50,7 @@ class RefreshCommand(BaseCommand):
             self._run_seeder(database)
 
     def _needs_seeding(self):
-        return self.option('seed') or self.option('seeder')
+        return self.option('seed')
 
     def _run_seeder(self, database):
         options = [

--- a/tests/commands/migrations/test_refresh_command.py
+++ b/tests/commands/migrations/test_refresh_command.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+
+import os
+from flexmock import flexmock
+from orator.migrations import Migrator
+from orator.commands.migrations import RefreshCommand
+from orator import DatabaseManager
+from .. import OratorCommandTestCase
+
+
+class RefreshCommandTestCase(OratorCommandTestCase):
+
+    def test_refresh_runs_the_seeder_when_seed_option_set(self):
+        resolver = flexmock(DatabaseManager)
+        resolver.should_receive('connection').and_return(None)
+
+        command = flexmock(RefreshCommand())
+        command.should_receive('_get_config').and_return({})
+        command.should_receive('confirm').and_return(True)
+        command.should_receive('call').with_args('migrate:reset', object).and_return(True)
+        command.should_receive('call').with_args('migrate', object).and_return(True)
+        command.should_receive('_run_seeder')
+
+        self.run_command(command, [('--seed')])
+
+    def test_refresh_does_not_run_the_seeder_when_seed_option_absent(self):
+        resolver = flexmock(DatabaseManager)
+        resolver.should_receive('connection').and_return(None)
+
+        command = flexmock(RefreshCommand())
+        command.should_receive('_get_config').and_return({})
+        command.should_receive('confirm').and_return(True)
+        command.should_receive('call').with_args('migrate:reset', object).and_return(True)
+        command.should_receive('call').with_args('migrate', object).and_return(True)
+
+        self.run_command(command, [])


### PR DESCRIPTION
`migrate:refresh` was previously running the seeds even when `—seed` was not provided
as an option. This commit provides a test and fixes the behavior.