### PR TITLE
Added table prefix to the DatabaseMigrationRepository

### DIFF
--- a/orator/migrations/database_migration_repository.py
+++ b/orator/migrations/database_migration_repository.py
@@ -11,8 +11,8 @@ class DatabaseMigrationRepository(object):
         :type table: str
         """
         self._resolver = resolver
-        self._table = table
         self._connection = None
+        self._table = self.get_connection().get_table_prefix() + table
 
     def get_ran(self):
         """


### PR DESCRIPTION
Added prefix to the 'table' attribute in the
DatabaseMigrationRepository class. Previously the prefix
was ignored, causing a QueryException.

This also fixes #176