### PR TITLE
Fix the get_float_type_declaration error for sqlite

### DIFF
--- a/orator/__init__.py
+++ b/orator/__init__.py
@@ -7,3 +7,4 @@ from .database_manager import DatabaseManager
 from .query.expression import QueryExpression
 from .schema import Schema
 from .pagination import Paginator, LengthAwarePaginator
+from .utils.initialize import initialize

--- a/orator/connections/connection.py
+++ b/orator/connections/connection.py
@@ -353,7 +353,7 @@ class Connection(ConnectionInterface):
                   'SSL connection has been closed unexpectedly',
                   'Error writing data to the connection',
                   'Resource deadlock avoided',]:
-            if s in message:
+            if s.upper() in message.upper():
                 return True
 
         return False

--- a/orator/dbal/platforms/sqlite_platform.py
+++ b/orator/dbal/platforms/sqlite_platform.py
@@ -533,6 +533,9 @@ class SQLitePlatform(Platform):
         else:
             return 'VARCHAR(%s)' % length if length else 'TEXT'
 
+    def get_float_type_declaration_sql(self, column):
+        return 'REAL'
+
     def get_blob_type_declaration_sql(self, column):
         return 'BLOB'
 

--- a/orator/utils/initialize.py
+++ b/orator/utils/initialize.py
@@ -1,0 +1,19 @@
+import orator
+import yaml
+from orator import Model, DatabaseManager
+from orator.migrations import Migrator, DatabaseMigrationRepository
+
+def initialize(config_file='orator.yml', run_migrations=True, migrations_dir="migrations"):
+	with open(config_file) as file:
+		config = yaml.load(file)
+	
+	db = DatabaseManager(config['databases'])
+	Model.set_connection_resolver(db)
+
+	if run_migrations:
+		repository = DatabaseMigrationRepository(db, 'migrations')
+		migrator = Migrator(repository, db)
+		if not migrator.repository_exists():
+			repository.create_repository()
+
+		migrator.run(migrations_dir)


### PR DESCRIPTION
Implement the function that returns the sqlite-equivalent 'float' type ("REAL"). This resolves an error that is thrown when attempting a migration containing a "float" column on a sqlite database.