### PR TITLE
Adds an option to add columns with time zone

### DIFF
--- a/orator/schema/blueprint.py
+++ b/orator/schema/blueprint.py
@@ -558,7 +558,7 @@ class Blueprint(object):
         """
         return self._add_column('date', column)
 
-    def datetime(self, column):
+    def datetime(self, column, with_time_zone=False):
         """
         Create a new datetime column on the table.
 
@@ -567,9 +567,9 @@ class Blueprint(object):
 
         :rtype: Fluent
         """
-        return self._add_column('datetime', column)
+        return self._add_column('datetime', column, with_time_zone=with_time_zone)
 
-    def time(self, column):
+    def time(self, column, with_time_zone=False):
         """
         Create a new time column on the table.
 
@@ -578,9 +578,9 @@ class Blueprint(object):
 
         :rtype: Fluent
         """
-        return self._add_column('time', column)
+        return self._add_column('time', column, with_time_zone=with_time_zone)
 
-    def timestamp(self, column):
+    def timestamp(self, column, with_time_zone=False):
         """
         Create a new timestamp column on the table.
 
@@ -589,7 +589,7 @@ class Blueprint(object):
 
         :rtype: Fluent
         """
-        return self._add_column('timestamp', column)
+        return self._add_column('timestamp', column, with_time_zone=with_time_zone)
 
     def nullable_timestamps(self):
         """
@@ -600,26 +600,26 @@ class Blueprint(object):
         self.timestamp('created_at').nullable()
         self.timestamp('updated_at').nullable()
 
-    def timestamps(self, use_current=True):
+    def timestamps(self, use_current=True, with_time_zone=False):
         """
         Create creation and update timestamps to the table.
 
         :rtype: Fluent
         """
         if use_current:
-            self.timestamp('created_at').use_current()
-            self.timestamp('updated_at').use_current()
+            self.timestamp('created_at', with_time_zone=with_time_zone).use_current()
+            self.timestamp('updated_at', with_time_zone=with_time_zone).use_current()
         else:
-            self.timestamp('created_at')
-            self.timestamp('updated_at')
+            self.timestamp('created_at', with_time_zone=with_time_zone)
+            self.timestamp('updated_at', with_time_zone=with_time_zone)
 
-    def soft_deletes(self):
+    def soft_deletes(self, with_time_zone=False):
         """
         Add a "deleted at" timestamp to the table.
 
         :rtype: Fluent
         """
-        return self.timestamp('deleted_at').nullable()
+        return self.timestamp('deleted_at', with_time_zone=with_time_zone).nullable()
 
     def binary(self, column):
         """

--- a/orator/schema/grammars/postgres_grammar.py
+++ b/orator/schema/grammars/postgres_grammar.py
@@ -183,16 +183,21 @@ class PostgresSchemaGrammar(SchemaGrammar):
         return 'DATE'
 
     def _type_datetime(self, column):
-        return 'TIMESTAMP(0) WITHOUT TIME ZONE'
+        return 'TIMESTAMP(0) %s' % self._time_zone(column)
 
     def _type_time(self, column):
-        return 'TIME(0) WITHOUT TIME ZONE'
+        return 'TIME(0) %s' % self._time_zone(column)
 
     def _type_timestamp(self, column):
         if column.use_current:
-            return 'TIMESTAMP(0) WITHOUT TIME ZONE DEFAULT CURRENT_TIMESTAMP(0)'
+            return 'TIMESTAMP(0) %s DEFAULT CURRENT_TIMESTAMP(0)' % self._time_zone(column)
 
-        return 'TIMESTAMP(0) WITHOUT TIME ZONE'
+        return 'TIMESTAMP(0) %s' % self._time_zone(column)
+
+    def _time_zone(self, column):
+        with_or_without = 'WITH' if column.with_time_zone else 'WITHOUT'
+
+        return '%s TIME ZONE' % with_or_without
 
     def _type_binary(self, column):
         return 'BYTEA'

--- a/tests/schema/grammars/test_postgres_grammar.py
+++ b/tests/schema/grammars/test_postgres_grammar.py
@@ -409,6 +409,16 @@ class PostgresSchemaGrammarTestCase(OratorTestCase):
             statements[0]
         )
 
+        blueprint = Blueprint('users')
+        blueprint.datetime('foo', with_time_zone=True).with_time_zone()
+        statements = blueprint.to_sql(self.get_connection(), self.get_grammar())
+
+        self.assertEqual(1, len(statements))
+        self.assertEqual(
+            'ALTER TABLE "users" ADD COLUMN "foo" TIMESTAMP(0) WITH TIME ZONE NOT NULL',
+            statements[0]
+        )
+
     def test_adding_time(self):
         blueprint = Blueprint('users')
         blueprint.time('foo')
@@ -417,6 +427,16 @@ class PostgresSchemaGrammarTestCase(OratorTestCase):
         self.assertEqual(1, len(statements))
         self.assertEqual(
             'ALTER TABLE "users" ADD COLUMN "foo" TIME(0) WITHOUT TIME ZONE NOT NULL',
+            statements[0]
+        )
+
+        blueprint = Blueprint('users')
+        blueprint.time('foo', with_time_zone=True)
+        statements = blueprint.to_sql(self.get_connection(), self.get_grammar())
+
+        self.assertEqual(1, len(statements))
+        self.assertEqual(
+            'ALTER TABLE "users" ADD COLUMN "foo" TIME(0) WITH TIME ZONE NOT NULL',
             statements[0]
         )
 
@@ -431,6 +451,16 @@ class PostgresSchemaGrammarTestCase(OratorTestCase):
             statements[0]
         )
 
+        blueprint = Blueprint('users')
+        blueprint.timestamp('foo', with_time_zone=True)
+        statements = blueprint.to_sql(self.get_connection(), self.get_grammar())
+
+        self.assertEqual(1, len(statements))
+        self.assertEqual(
+            'ALTER TABLE "users" ADD COLUMN "foo" TIMESTAMP(0) WITH TIME ZONE NOT NULL',
+            statements[0]
+        )
+
     def test_adding_timestamp_with_current(self):
         blueprint = Blueprint('users')
         blueprint.timestamp('foo').use_current()
@@ -439,6 +469,17 @@ class PostgresSchemaGrammarTestCase(OratorTestCase):
         self.assertEqual(1, len(statements))
         self.assertEqual(
             'ALTER TABLE "users" ADD COLUMN "foo" TIMESTAMP(0) WITHOUT TIME ZONE DEFAULT CURRENT_TIMESTAMP(0) NOT NULL',
+            statements[0]
+        )
+
+        blueprint = Blueprint('users')
+        blueprint.timestamp('foo', with_time_zone=True).use_current()
+        statements = blueprint.to_sql(self.get_connection(), self.get_grammar())
+
+        self.assertEqual(1, len(statements))
+        self.assertEqual(
+            'ALTER TABLE "users" ADD COLUMN "foo" TIMESTAMP(0) WITH TIME ZONE '
+            'DEFAULT CURRENT_TIMESTAMP(0) NOT NULL',
             statements[0]
         )
 
@@ -457,6 +498,21 @@ class PostgresSchemaGrammarTestCase(OratorTestCase):
             statements[0]
         )
 
+        blueprint = Blueprint('users')
+        blueprint.timestamps(with_time_zone=True)
+        statements = blueprint.to_sql(self.get_connection(), self.get_grammar())
+
+        self.assertEqual(1, len(statements))
+        expected = [
+            'ALTER TABLE "users" ADD COLUMN "created_at" TIMESTAMP(0) WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP(0) NOT NULL, '
+            'ADD COLUMN "updated_at" TIMESTAMP(0) WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP(0) NOT NULL'
+        ]
+
+        self.assertEqual(
+            expected[0],
+            statements[0]
+        )
+
     def test_adding_timestamps_not_current(self):
         blueprint = Blueprint('users')
         blueprint.timestamps(use_current=False)
@@ -466,6 +522,20 @@ class PostgresSchemaGrammarTestCase(OratorTestCase):
         expected = [
             'ALTER TABLE "users" ADD COLUMN "created_at" TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL, '
             'ADD COLUMN "updated_at" TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL'
+        ]
+        self.assertEqual(
+            expected[0],
+            statements[0]
+        )
+
+        blueprint = Blueprint('users')
+        blueprint.timestamps(use_current=False, with_time_zone=True)
+        statements = blueprint.to_sql(self.get_connection(), self.get_grammar())
+
+        self.assertEqual(1, len(statements))
+        expected = [
+            'ALTER TABLE "users" ADD COLUMN "created_at" TIMESTAMP(0) WITH TIME ZONE NOT NULL, '
+            'ADD COLUMN "updated_at" TIMESTAMP(0) WITH TIME ZONE NOT NULL'
         ]
         self.assertEqual(
             expected[0],


### PR DESCRIPTION
Adds an option to create time related columns like `time`, `timestamp` and
`datetime` with the option "with time zone" instead of just without it.
So we wouldn't break BC, the default is still false.
This is done by passing a `with_time_zone=True` as a parameter when
creating columns and so we don't break BC, the default is `False`.

Example:

```python
with schema.table('users') as table:
    table.string('name')
    table.timestamps(with_time_zone=True)
    table.soft_deletes(with_time_zone=True)
```

This PR closes issue #185