### PR TITLE
Using decode('utf-8') to fix decoding non-ASCII characters (for example, Chinese) error

### DIFF
--- a/orator/connections/mysql_connection.py
+++ b/orator/connections/mysql_connection.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from ..utils import decode
 from ..utils import PY2
 from .connection import Connection
 from ..query.grammars.mysql_grammar import MySQLQueryGrammar
@@ -62,6 +63,6 @@ class MySQLConnection(Connection):
             return super(MySQLConnection, self)._get_cursor_query(query, bindings)
 
         if PY2:
-            return self._cursor._last_executed.decode()
+            return decode(self._cursor._last_executed)
 
         return self._cursor._last_executed


### PR DESCRIPTION
Using decode('utf-8') to fix decoding non-ASCII characters (for example, Chinese) error.The problem may also exist in postgres_connection. py
example
```python
# coding: utf-8

from orator import DatabaseManager
import logging
log = logging.getLogger('orator')
log.setLevel(logging.DEBUG)
log.addHandler(logging.StreamHandler())

config = {
    'default': 'yh_edu',
    'yh_edu': {
        'driver': 'mysql',
        'host': '192.168.6.107',
        'database': 'yh_edu',
        'port': 3307,
        'user': 'root',
        'password': '123456',
        'use_qmark': True,
        'log_queries': True
    },
}

db = DatabaseManager(config)

# log error
us = db.table('auth_user').where('name', u'中文').get()
for u in us:
    print u
```