### PR TITLE
Fixed lost connection bug

### DIFF
--- a/orator/connections/connection.py
+++ b/orator/connections/connection.py
@@ -353,7 +353,7 @@ class Connection(ConnectionInterface):
                   'SSL connection has been closed unexpectedly',
                   'Error writing data to the connection',
                   'Resource deadlock avoided',]:
-            if s in message:
+            if s.upper() in message.upper():
                 return True
 
         return False


### PR DESCRIPTION
On MariaDB, the error message for a lost connection reads:

`Lost connection to MySQL server during query`

Orator looks for the string `Lost Connection` in this message to determine if the problem can be resolved by re-connecting, but the upper-casing is off.

This is fixed by transforming both the search text and the error message to uppercase before comparison, to maintain compatibility between different implementations of MySQL.