### PR TITLE
Add initialization function

### DIFF
--- a/orator/__init__.py
+++ b/orator/__init__.py
@@ -7,3 +7,4 @@ from .database_manager import DatabaseManager
 from .query.expression import QueryExpression
 from .schema import Schema
 from .pagination import Paginator, LengthAwarePaginator
+from .utils.initialize import initialize

--- a/orator/utils/initialize.py
+++ b/orator/utils/initialize.py
@@ -1,0 +1,19 @@
+import orator
+import yaml
+from orator import Model, DatabaseManager
+from orator.migrations import Migrator, DatabaseMigrationRepository
+
+def initialize(config_file='orator.yml', run_migrations=True, migrations_dir="migrations"):
+	with open(config_file) as file:
+		config = yaml.load(file)
+	
+	db = DatabaseManager(config['databases'])
+	Model.set_connection_resolver(db)
+
+	if run_migrations:
+		repository = DatabaseMigrationRepository(db, 'migrations')
+		migrator = Migrator(repository, db)
+		if not migrator.repository_exists():
+			repository.create_repository()
+
+		migrator.run(migrations_dir)


### PR DESCRIPTION
If you use Orator in your applications, a common scenario is that you wish to create the database connection on startup and to run all migrations before starting the application. Previously, one would have to do something like:

```
from orator import Model, DatabaseManager
from orator.migrations import Migrator, DatabaseMigrationRepository
import yaml

with open("orator.yml") as file:
        config = yaml.load(file)

# Create connection
db = DatabaseManager(config['databases'])
Model.set_connection_resolver(db)

# Check for migrations
repository = DatabaseMigrationRepository(db, 'migrations')
migrator = Migrator(repository, db)
if not migrator.repository_exists():
    repository.create_repository()

migrations_dir = os.path.append(os.path.dirname(os.path.abspath(__file__)), "migrations")
migrator.run(migrations_dir)

```

With this new convenience function, this is reduced to:

```
import orator
orator.initialize()
```

Optionally, you can provide the location for the config file, the migrations dir, and whether or not you want to run the migrations:

```
import orator

config_file = "config/orator.yml"
migrations_dir ="my_migrations"

orator.initialize(config_file="config/orator.yml", migrations_dir="my_migrations")
```

Or, if you don't want to run the migrations:

```
import orator
orator.initialize(run_migrations=False)
```

The defaults values for these parameters are the same that are used by the Orator CLI.