### PR TITLE
Fix the get_float_type_declaration error for sqlite

### DIFF
--- a/orator/dbal/platforms/sqlite_platform.py
+++ b/orator/dbal/platforms/sqlite_platform.py
@@ -533,6 +533,9 @@ class SQLitePlatform(Platform):
         else:
             return 'VARCHAR(%s)' % length if length else 'TEXT'
 
+    def get_float_type_declaration_sql(self, column):
+        return 'REAL'
+
     def get_blob_type_declaration_sql(self, column):
         return 'BLOB'
 


### PR DESCRIPTION
Implement the function that returns the sqlite-equivalent 'float' type ("REAL"). This resolves an error that would be thrown when attempting a migration containing a "float" column on a sqlite database.