### PR TITLE
Fix save_many for PY3

### DIFF
--- a/orator/orm/relations/has_one_or_many.py
+++ b/orator/orm/relations/has_one_or_many.py
@@ -171,7 +171,7 @@ class HasOneOrMany(Relation):
 
         :rtype: list
         """
-        return map(self.save, models)
+        return list(map(self.save, models))
 
     def find_or_new(self, id, columns=None):
         """


### PR DESCRIPTION
In PY3, the 'map' builtin returns an iterator, not a list. This means that calling save_many without capturing the return value (a totally valid use case, taken straight from the docs) literally doesn't do anything.