### PR TITLE
Fix save_many for PY3

### DIFF
--- a/orator/orm/relations/has_one_or_many.py
+++ b/orator/orm/relations/has_one_or_many.py
@@ -171,7 +171,7 @@ class HasOneOrMany(Relation):
 
         :rtype: list
         """
-        return map(self.save, models)
+        return list(map(self.save, models))
 
     def find_or_new(self, id, columns=None):
         """

--- a/tests/orm/relations/test_has_many.py
+++ b/tests/orm/relations/test_has_many.py
@@ -148,6 +148,21 @@ class OrmHasManyTestCase(OratorTestCase):
 
         relation.add_eager_constraints([model1, model2])
 
+    def test_save_many_returns_list_of_models(self):
+        relation = self._get_relation()
+
+        model1 = flexmock()
+        model1.foo = 'foo'
+        model1.should_receive('save').once().and_return(True)
+        model1.should_receive('set_attribute').once().with_args('foreign_key', 1)
+
+        model2 = flexmock()
+        model2.foo = 'bar'
+        model2.should_receive('save').once().and_return(True)
+        model2.should_receive('set_attribute').once().with_args('foreign_key', 1)
+
+        self.assertEqual([model1, model2], relation.save_many([model1, model2]))
+
     def test_models_are_properly_matched_to_parents(self):
         relation = self._get_relation()
 


### PR DESCRIPTION
In PY3, the 'map' builtin returns an iterator, not a list. This means that calling save_many without capturing the return value (a totally valid use case, taken straight from the docs) literally doesn't do anything.