### PR TITLE
Move Faker dependency to [tool.poetry.dev-dependencies]

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,6 @@ backpack = "^0.1"
 blinker = "^1.4"
 cleo = "^0.6"
 inflection = "^0.3"
-Faker = "^0.8"
 lazy-object-proxy = "^1.2"
 pendulum = "^1.4"
 pyaml = "^16.12"
@@ -43,6 +42,7 @@ mysqlclient = { version = "^1.3", optional = true }
 flexmock = "0.9.7"
 pytest = "^3.5"
 pytest-mock = "^1.6"
+Faker = "^0.8"
 
 
 [tool.poetry.extras]


### PR DESCRIPTION
Faker is a test data generator and shouldn't be a build dependency of orator.

Fixes #250 