### PR TITLE
:pencil: Add CONTRIBUTING doc.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,34 @@
+# Contributing
+All kind of contribution is welcome: reporting new issues, pull requests or tweeting about this project.
+
+
+## Installation
+In this section we will focus to setup the project to run the tests in our local environment. 
+
+Orator supports many python versions and also multiple databases so the setup can be a little difficult. To make it as easy as possible we will use docker and docker-compose.
+
+But before beginning there are some prerequisites to setup the environment.
+
+### Prerequisites
+  * [docker](https://docs.docker.com/install/)
+  * [docker-compose](https://docs.docker.com/compose/install/)
+
+### Instructions
+We already prepared all the images to permit to start the test environment with one command:
+
+```cmd
+make start-containers
+```
+
+This will start the databases::
+  * postgres 9.6
+  * mysql 5.6
+
+
+### Run tests
+Now you can try to execute the tests:
+
+```cmd
+make test
+```
+

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,8 @@
 # http://www.opensource.org/licenses/MIT-license
 # Copyright (c) 2015 Sébastien Eustace
 
+DOCKER_COMPOSE=docker-compose -f tests/docker/docker-compose.yml --project-directory .
+
 # lists all available targets
 list:
 	@sh -c "$(MAKE) -p no_targets__ | \
@@ -56,12 +58,14 @@ extensions:
 	cython orator/support/_collection.pyx
 	cython orator/utils/_helpers.pyx
 
-# test your application (tests in the tests/ directory)
 test:
-	@py.test tests -sq
+	${DOCKER_COMPOSE} exec orator poetry run pytest tests
 
-# run tests against all supported python versions
-tox:
-	@poet make:setup
-	@tox
-	@rm -f setup.py
+start-containers:
+	${DOCKER_COMPOSE} up -d
+
+stop-containers:
+	${DOCKER_COMPOSE} stop
+
+remove-containers:
+	${DOCKER_COMPOSE} down

--- a/tests/docker/docker-compose.yml
+++ b/tests/docker/docker-compose.yml
@@ -1,0 +1,35 @@
+version: '3'
+
+services:
+  orator:
+    build:
+      context: .
+      dockerfile: ./tests/docker/orator/Dockerfile
+    volumes:
+      - .:/code
+    working_dir: /code
+    tty: true
+    links:
+      - postgres:postgres-db
+      - mysql:mysql-db
+    depends_on:
+      - postgres
+      - mysql
+
+  postgres:
+    image: postgres:9.6
+    volumes:
+      - orator_postgres:/var/lib/postgresql
+      - ./tests/docker/postgres:/docker-entrypoint-initdb.d
+
+  mysql:
+    image: mysql:5.6
+    environment:
+      - MYSQL_ROOT_PASSWORD=orator
+    volumes:
+      - orator_mysql:/var/lib/mysql
+      - ./tests/docker/mysql:/docker-entrypoint-initdb.d
+
+volumes:
+  orator_postgres: {}
+  orator_mysql: {}

--- a/tests/docker/mysql/0_users.sql
+++ b/tests/docker/mysql/0_users.sql
@@ -1,0 +1,1 @@
+CREATE USER 'orator'@'%' IDENTIFIED BY 'orator';

--- a/tests/docker/mysql/1_databases.sql
+++ b/tests/docker/mysql/1_databases.sql
@@ -1,0 +1,2 @@
+CREATE DATABASE orator_test;
+USE orator_test; GRANT ALL PRIVILEGES ON orator_test.* TO 'orator'@'%';

--- a/tests/docker/orator/Dockerfile
+++ b/tests/docker/orator/Dockerfile
@@ -1,0 +1,8 @@
+FROM python:3.7
+ENV PYTHONUNBUFFERED 1
+RUN mkdir -p /code
+WORKDIR /code
+RUN curl -sSL https://raw.githubusercontent.com/sdispater/poetry/master/get-poetry.py | python
+ENV PATH="/root/.poetry/bin:${PATH}"
+COPY . /code
+RUN poetry install --extras mysql-python --extras pgsql

--- a/tests/docker/postgres/0_users.sql
+++ b/tests/docker/postgres/0_users.sql
@@ -1,0 +1,1 @@
+CREATE USER orator WITH ENCRYPTED PASSWORD 'orator';

--- a/tests/docker/postgres/1_databases.sql
+++ b/tests/docker/postgres/1_databases.sql
@@ -1,0 +1,2 @@
+CREATE DATABASE orator_test;
+GRANT ALL PRIVILEGES ON DATABASE orator_test TO orator;

--- a/tests/integrations/test_mysql.py
+++ b/tests/integrations/test_mysql.py
@@ -15,10 +15,12 @@ class MySQLIntegrationTestCase(IntegrationTestCase, OratorTestCase):
             database = "orator_test"
             user = "root"
             password = ""
+            host = "localhost"
         else:
             database = "orator_test"
             user = "orator"
             password = "orator"
+            host = "mysql-db"
 
         return {
             "default": "mysql",
@@ -27,6 +29,7 @@ class MySQLIntegrationTestCase(IntegrationTestCase, OratorTestCase):
                 "database": database,
                 "user": user,
                 "password": password,
+                "host": host,
             },
         }
 

--- a/tests/integrations/test_mysql_qmark.py
+++ b/tests/integrations/test_mysql_qmark.py
@@ -15,10 +15,12 @@ class MySQLQmarkIntegrationTestCase(IntegrationTestCase, OratorTestCase):
             database = "orator_test"
             user = "root"
             password = ""
+            host = "localhost"
         else:
             database = "orator_test"
             user = "orator"
             password = "orator"
+            host = "mysql-db"
 
         return {
             "default": "mysql",
@@ -28,6 +30,7 @@ class MySQLQmarkIntegrationTestCase(IntegrationTestCase, OratorTestCase):
                 "user": user,
                 "password": password,
                 "use_qmark": True,
+                "host": host,
             },
         }
 

--- a/tests/integrations/test_postgres.py
+++ b/tests/integrations/test_postgres.py
@@ -15,10 +15,12 @@ class PostgresIntegrationTestCase(IntegrationTestCase, OratorTestCase):
             database = "orator_test"
             user = "postgres"
             password = None
+            host = "localhost"
         else:
             database = "orator_test"
             user = "orator"
             password = "orator"
+            host = "postgres-db"
 
         return {
             "default": "postgres",
@@ -27,6 +29,7 @@ class PostgresIntegrationTestCase(IntegrationTestCase, OratorTestCase):
                 "database": database,
                 "user": user,
                 "password": password,
+                "host": host,
             },
         }
 

--- a/tests/integrations/test_postgres_qmark.py
+++ b/tests/integrations/test_postgres_qmark.py
@@ -15,10 +15,12 @@ class PostgresQmarkIntegrationTestCase(IntegrationTestCase, OratorTestCase):
             database = "orator_test"
             user = "postgres"
             password = None
+            host = "localhost"
         else:
             database = "orator_test"
             user = "orator"
             password = "orator"
+            host = "postgres-db"
 
         return {
             "default": "postgres",
@@ -28,6 +30,7 @@ class PostgresQmarkIntegrationTestCase(IntegrationTestCase, OratorTestCase):
                 "user": user,
                 "password": password,
                 "use_qmark": True,
+                "host": host,
             },
         }
 

--- a/tests/schema/integrations/test_mysql.py
+++ b/tests/schema/integrations/test_mysql.py
@@ -26,14 +26,16 @@ class DatabaseIntegrationConnectionResolver(object):
             database = "orator_test"
             user = "root"
             password = ""
+            host = "localhost"
         else:
             database = "orator_test"
             user = "orator"
             password = "orator"
+            host = "mysql-db"
 
         self._connection = MySQLConnection(
             MySQLConnector().connect(
-                {"database": database, "user": user, "password": password}
+                {"database": database, "user": user, "password": password, "host": host}
             )
         )
 

--- a/tests/schema/integrations/test_postgres.py
+++ b/tests/schema/integrations/test_postgres.py
@@ -26,14 +26,16 @@ class DatabaseIntegrationConnectionResolver(object):
             database = "orator_test"
             user = "postgres"
             password = None
+            host = "localhost"
         else:
             database = "orator_test"
             user = "orator"
             password = "orator"
+            host = "postgres-db"
 
         self._connection = PostgresConnection(
             PostgresConnector().connect(
-                {"database": database, "user": user, "password": password}
+                {"database": database, "user": user, "password": password, "host": host}
             )
         )
 


### PR DESCRIPTION
Also add docker support, so that Orator development can take place without the need to install postgres and mysql natively.

Ref : https://github.com/sdispater/orator/pull/293
By @psincraian 