### PR TITLE
Fix deprecation warning when working with commands

### DIFF
--- a/orator/commands/command.py
+++ b/orator/commands/command.py
@@ -118,7 +118,7 @@ class Command(BaseCommand):
         filename, ext = os.path.splitext(path)
         if ext in [".yml", ".yaml"]:
             with open(path) as fd:
-                config = yaml.load(fd)
+                config = yaml.load(fd, Loader=yaml.FullLoader)
         elif ext in [".py"]:
             config = {}
 


### PR DESCRIPTION
When using commands got warning 'YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.'

Added loader as described in doc. Works perfect, no deprecation warnings.