### PR TITLE
[fix #346]fix logging out chinese

### DIFF
--- a/orator/connections/connection.py
+++ b/orator/connections/connection.py
@@ -416,7 +416,7 @@ class Connection(ConnectionInterface):
                 log += " in %sms" % time_
 
             query_logger.debug(
-                log, extra={"query": query, "bindings": bindings, "elapsed_time": time_}
+                log, extra={"query": query.decode("utf-8"), "bindings": bindings, "elapsed_time": time_}
             )
 
     def _get_elapsed_time(self, start):


### PR DESCRIPTION
eg:
before
```
b"SELECT `id` FROM `company` WHERE `company` = '\xe6\xb7\xb1\xe5\x9c\xb3\xe5\xb8\x82\xe6\x98\x9f\xe6\x9c\x9f\xe9\x9b\xb6\xe9\xa3\x9f\xe5\x93\x81\xe7\xa7\x91\xe6\x8a\x80\xe6\x9c\x89\xe9\x99\x90\xe5\x85\xac\xe5\x8f\xb8' LIMIT 1"
```

after
```
SELECT `id` FROM `company` WHERE `company` = '深圳市星期零食品科技有限公司' LIMIT 1
```