### PR TITLE
Fix Pendulum Import Errors

### DIFF
--- a/orator/connectors/mysql_connector.py
+++ b/orator/connectors/mysql_connector.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 
-import re
-from pendulum import Pendulum, Date
+import re, pendulum
 
 try:
     import MySQLdb as mysql
@@ -9,8 +8,8 @@ try:
     # Fix for understanding Pendulum object
     import MySQLdb.converters
 
-    MySQLdb.converters.conversions[Pendulum] = MySQLdb.converters.DateTime2literal
-    MySQLdb.converters.conversions[Date] = MySQLdb.converters.Thing2Literal
+    MySQLdb.converters.conversions[pendulum] = MySQLdb.converters.DateTime2literal
+    MySQLdb.converters.conversions[pendulum.Date] = MySQLdb.converters.Thing2Literal
 
     from MySQLdb.cursors import DictCursor as cursor_class
 

--- a/orator/connectors/sqlite_connector.py
+++ b/orator/connectors/sqlite_connector.py
@@ -1,14 +1,14 @@
 # -*- coding: utf-8 -*-
 
-from pendulum import Pendulum, Date
+import pendulum
 
 try:
     import sqlite3
 
     from sqlite3 import register_adapter
 
-    register_adapter(Pendulum, lambda val: val.isoformat(" "))
-    register_adapter(Date, lambda val: val.isoformat())
+    register_adapter(pendulum, lambda val: val.isoformat(" "))
+    register_adapter(pendulum.Date, lambda val: val.isoformat())
 except ImportError:
     sqlite3 = None
 

--- a/tests/orm/test_model.py
+++ b/tests/orm/test_model.py
@@ -4,7 +4,7 @@ import simplejson as json
 import hashlib
 import time
 import datetime
-from pendulum import Pendulum
+import pendulum
 from flexmock import flexmock, flexmock_teardown
 from .. import OratorTestCase, mock
 from ..utils import MockModel, MockQueryBuilder, MockConnection, MockProcessor
@@ -348,8 +348,8 @@ class OrmModelTestCase(OratorTestCase):
             {"created_at": "2015-03-24", "updated_at": "2015-03-24"}
         )
 
-        self.assertIsInstance(model.created_at, Pendulum)
-        self.assertIsInstance(model.updated_at, Pendulum)
+        self.assertIsInstance(model.created_at, pendulum)
+        self.assertIsInstance(model.updated_at, pendulum)
 
     def test_timestamps_are_returned_as_objects_from_timestamps_and_datetime(self):
         model = Model()
@@ -357,8 +357,8 @@ class OrmModelTestCase(OratorTestCase):
             {"created_at": datetime.datetime.utcnow(), "updated_at": time.time()}
         )
 
-        self.assertIsInstance(model.created_at, Pendulum)
-        self.assertIsInstance(model.updated_at, Pendulum)
+        self.assertIsInstance(model.created_at, pendulum)
+        self.assertIsInstance(model.updated_at, pendulum)
 
     def test_timestamps_are_returned_as_objects_on_create(self):
         model = Model()
@@ -371,8 +371,8 @@ class OrmModelTestCase(OratorTestCase):
 
         instance = model.new_instance(timestamps)
 
-        self.assertIsInstance(instance.created_at, Pendulum)
-        self.assertIsInstance(instance.updated_at, Pendulum)
+        self.assertIsInstance(instance.created_at, pendulum)
+        self.assertIsInstance(instance.updated_at, pendulum)
 
         model.reguard()
 


### PR DESCRIPTION
**Why*

This change fixes an import error with Pendulum.

In existing implementations folks will get the following error: 

ImportError: cannot import name 'Pendulum' from 'pendulum'

**What Changed**

Migrating the pendulum imports.