### PR TITLE
Make SQLitePlatform support float type

### DIFF
--- a/orator/dbal/platforms/sqlite_platform.py
+++ b/orator/dbal/platforms/sqlite_platform.py
@@ -480,6 +480,9 @@ class SQLitePlatform(Platform):
     def get_integer_type_declaration_sql(self, column):
         return 'INTEGER' + self._get_common_integer_type_declaration_sql(column)
 
+    def get_float_type_declaration_sql(self, column):
+        return 'FLOAT'
+
     def get_bigint_type_declaration_sql(self, column):
         # SQLite autoincrement is implicit for INTEGER PKs, but not for BIGINT fields.
         if not column.get('autoincrement', False):


### PR DESCRIPTION
DB: sqlite.

State: database with table and many columns (including double)
Action: run migration that removes a column (in my case - not double)
Result: migration failes with
                                                        
>  [AttributeError]                                                           
> 'SQLitePlatform' object has no attribute 'get_float_type_declaration_sql'

After I resolve the SQLitePlatform.get_float_type_declaration_sql, the migration runs just fine.