### PR TITLE
get_attribute to consider fillable attributes

### DIFF
--- a/orator/orm/model.py
+++ b/orator/orm/model.py
@@ -2401,7 +2401,7 @@ class Model(object):
         :param key: The attribute to get
         :type key: str
         """
-        in_attributes = key in self._attributes
+        in_attributes = key in self._attributes or self.is_fillable(key)
 
         if in_attributes:
             return self._get_attribute_value(key)
@@ -2588,7 +2588,7 @@ class Model(object):
     def from_datetime(self, value):
         """
         Convert datetime to a storable string.
-        
+
         :param value: The datetime value
         :type value: pendulum.Pendulum or datetime.date or datetime.datetime
 

--- a/tests/orm/test_model.py
+++ b/tests/orm/test_model.py
@@ -912,6 +912,24 @@ class OrmModelTestCase(OratorTestCase):
         except AttributeError:
             pass
 
+    def test_get_attribute_unknown_key(self):
+        model = OrmModelStub()
+
+        try:
+            model.unknown_attribute
+            self.fail("AttributeError not raised")
+        except AttributeError:
+            pass
+
+    def test_get_attribute_unknown_but_fillable_key(self):
+        model = OrmModelStub()
+        model.fillable(['unknown_attribute'])
+
+        try:
+            model.unknown_attribute
+        except AttributeError:
+            self.fail("AttributeError raised for fillable key")
+
     def test_increment(self):
         query = flexmock()
         model_mock = flexmock(OrmModelStub, new_query=lambda: query)


### PR DESCRIPTION
Hey @sdispater, not sure whether you accept outside PRs, but would you consider attributes defined in the `__fillable__` array to be honored by the `get_attribute` method?

``` python
class Person(Model):
  __fillable__ = ['name']

person = Person()

print(person.name) # expect None, get AttributeError
```

---
_(I am fairly new to Python and was not able to run the test suite, so while it looks like my tests should work, I wasn't actually able to run them)_
