### PR TITLE
fix: Add two more messages to error connections

### DIFF
--- a/orator/connections/connection.py
+++ b/orator/connections/connection.py
@@ -371,6 +371,8 @@ class Connection(ConnectionInterface):
             "error writing data to the connection",
             "connection timed out",
             "resource deadlock avoided",
+            "connection already closed",
+            "EOF detected",
         ]:
             if s in message:
                 return True


### PR DESCRIPTION
The postgres has two more possibilites of erros when we lost the connection with database. It would be good try reconnect in this cases too.