### PR TITLE
docs: Fix a few typos

### DIFF
--- a/orator/orm/model.py
+++ b/orator/orm/model.py
@@ -203,7 +203,7 @@ class Model(object):
         :type scope: orator.orm.scopes.scope.Scope or callable or str
 
         :param implementation: The scope implementation
-        :type implementation: callbale or None
+        :type implementation: callable or None
         """
         if cls not in cls._global_scopes:
             cls._global_scopes[cls] = OrderedDict()
@@ -2180,7 +2180,7 @@ class Model(object):
     @classmethod
     def unguard(cls):
         """
-        Disable the mass assigment restrictions.
+        Disable the mass assignment restrictions.
         """
         cls.__unguarded__ = True
 

--- a/orator/orm/relations/belongs_to_many.py
+++ b/orator/orm/relations/belongs_to_many.py
@@ -704,7 +704,7 @@ class BelongsToMany(Relation):
 
     def _create_attach_record(self, id, timed):
         """
-        Create a new pivot attachement record.
+        Create a new pivot attachment record.
         """
         record = {}
 

--- a/orator/orm/relations/morph_to_many.py
+++ b/orator/orm/relations/morph_to_many.py
@@ -83,7 +83,7 @@ class MorphToMany(BelongsToMany):
 
     def _create_attach_record(self, id, timed):
         """
-        Create a new pivot attachement record.
+        Create a new pivot attachment record.
         """
         record = super(MorphToMany, self)._create_attach_record(id, timed)
 

--- a/orator/query/builder.py
+++ b/orator/query/builder.py
@@ -983,7 +983,7 @@ class QueryBuilder(object):
         :param id: The id of the record to retrieve
         :type id: mixed
 
-        :param columns: The columns of the record to retrive
+        :param columns: The columns of the record to retrieve
         :type columns: list
 
         :return: mixed
@@ -1263,7 +1263,7 @@ class QueryBuilder(object):
         """
         Retrieve the "min" result of the query
 
-        :param column: The column to get the minimun for
+        :param column: The column to get the minimum for
         :type column: tuple
 
         :return: The min
@@ -1318,7 +1318,7 @@ class QueryBuilder(object):
         :param func: The aggregate function
         :type func: str
 
-        :param columns: The columns to execute the fnction for
+        :param columns: The columns to execute the function for
         :type columns: tuple
 
         :return: The aggregate result

--- a/orator/schema/grammars/grammar.py
+++ b/orator/schema/grammars/grammar.py
@@ -130,7 +130,7 @@ class SchemaGrammar(Grammar):
 
     def _add_modifiers(self, sql, blueprint, column):
         """
-        Add the column modifiers to the deifinition
+        Add the column modifiers to the definition
         """
         for modifier in self._modifiers:
             method = "_modify_%s" % modifier


### PR DESCRIPTION
There are small typos in:
- orator/orm/model.py
- orator/orm/relations/belongs_to_many.py
- orator/orm/relations/morph_to_many.py
- orator/query/builder.py
- orator/schema/grammars/grammar.py

Fixes:
- Should read `attachment` rather than `attachement`.
- Should read `retrieve` rather than `retrive`.
- Should read `minimum` rather than `minimun`.
- Should read `function` rather than `fnction`.
- Should read `definition` rather than `deifinition`.
- Should read `callable` rather than `callbale`.
- Should read `assignment` rather than `assigment`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md